### PR TITLE
register patch fix

### DIFF
--- a/kairo-front/app/(auth)/register.tsx
+++ b/kairo-front/app/(auth)/register.tsx
@@ -1,67 +1,77 @@
+import { useAuth } from '@/src/contexts/AuthContext';
+import { registerRequest } from '@/src/lib/api';
 import { router, useLocalSearchParams as useSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { profileStyles as styles } from '../../global';
-import { useAuth } from '../../src/contexts/AuthContext';
-import { registerRequest } from '../../src/lib/api';
 
 export default function RegisterScreen() {
 	const { redirect } = useSearchParams() as { redirect?: string };
-	const { login } = useAuth(); // Use login() to store token if backend returns one
+	const { loginWithToken } = useAuth(); // Use loginWithToken() to store token if backend returns one
 	const [email, setEmail] = useState('');
 	const [password, setPassword] = useState('');
 	const [error, setError] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
 
-async function onSubmit(): Promise<void> {
-    setError(null);
-    setLoading(true);
+	async function onSubmit(): Promise<void> {
+		setError(null);
+		setLoading(true);
 
-	try {
-		const response = await registerRequest(email, password, 'mobile');
+		try {
+			const response = await registerRequest(email, password, 'mobile');
 
-	const token = response?.token ?? response.data?.token;
-		if (token) {
-			// Reminder to give devices actual names
-			// After login, go to requested redirect or home
-			if (redirect) router.replace(redirect as any);
-			else router.replace('/');
-		} else {
-            // backend may require email verification: show informative message and redirect to login
-            // router.replace(
-            //     `/login?showVerify=1&email=${encodeURIComponent(email)}&redirect=${encodeURIComponent(
-            //         redirect ?? '/'
-            //     )}`
-            // );
-        }
-	} catch (error: unknown) {
-		// If apiFetch throws, it sets error.body to parsed response when possible
-		console.error('Register error', error);
-		const body = (error as { body?: unknown }).body;
-		if (body && typeof body === 'object' && 'errors' in (body as Record<string, unknown>)) {
-			const errs = (body as Record<string, unknown>)['errors'] as unknown;
-			if (errs && typeof errs === 'object') {
-				// try to flatten if it's a Record<string, string[]>
-				try {
-					const messages = Object.values(errs as Record<string, string[]>).flat().join(' ');
-					setError(messages);
-				} catch {
+			const token = response?.token ?? response.data?.token;
+			if (token) {
+				// persist token so AuthProvider / app is authenticated
+				await setItemAsync('authToken', token);
+				// tell AuthContext about the new token so app updates immediately
+				await loginWithToken(token as string, redirect);
+			} else {
+				// backend may require email verification: show informative message and redirect to login
+				// TODO
+				router.replace(
+				    `/login?showVerify=1&email=${encodeURIComponent(email)}&redirect=${encodeURIComponent(
+				        redirect ?? '/'
+				    )}`
+				);
+			}
+		} catch (error: unknown) {
+			// If apiFetch throws, it sets error.body to parsed response when possible
+			console.error('Register error', error);
+			const body = (error as { body?: unknown }).body;
+			if (body && typeof body === 'object' && 'errors' in (body as Record<string, unknown>)) {
+				const errs = (body as Record<string, unknown>)['errors'] as unknown;
+				if (errs && typeof errs === 'object') {
+					// try to flatten if it's a Record<string, string[]>
+					try {
+						const errMap = errs as Record<string, unknown>;
+						const messages = Object.keys(errMap).reduce<string[]>((acc, key) => {
+							const val = errMap[key];
+							if (Array.isArray(val)) {
+								return acc.concat((val as unknown[]).map(String));
+							} else if (typeof val === 'string') {
+								acc.push(val as string);
+							}
+							return acc;
+						}, []).join(' ');
+						setError(messages);
+					} catch {
+						setError('Registration failed');
+					}
+				} else {
 					setError('Registration failed');
 				}
+			} else if (body && typeof body === 'object' && 'message' in (body as Record<string, unknown>)) {
+				setError(String((body as Record<string, unknown>)['message']));
+			} else if (typeof (error as { message?: unknown }).message === 'string') {
+				setError((error as { message?: string }).message ?? 'Registration failed');
 			} else {
 				setError('Registration failed');
 			}
-		} else if (body && typeof body === 'object' && 'message' in (body as Record<string, unknown>)) {
-			setError(String((body as Record<string, unknown>)['message']));
-		} else if (typeof (error as { message?: unknown }).message === 'string') {
-			setError((error as { message?: string }).message ?? 'Registration failed');
-		} else {
-			setError('Registration failed');
+		} finally {
+			setLoading(false);
 		}
-    } finally {
-        setLoading(false);
-    }
-}
+	}
 
 	return (
 		<View style={[styles.container, styles.center]}>

--- a/kairo-front/package.json
+++ b/kairo-front/package.json
@@ -22,6 +22,7 @@
     "@tamagui/lucide-icons": "^1.135.3",
     "expo": "~54.0.13",
     "expo-constants": "~18.0.9",
+    "expo-device": "^8.0.9",
     "expo-font": "~14.0.9",
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.9",

--- a/kairo-front/src/contexts/AuthContext.tsx
+++ b/kairo-front/src/contexts/AuthContext.tsx
@@ -18,6 +18,7 @@ type AuthContextType = {
   token: string | null;
   loading: boolean;
   login: (email: string, password: string, device_name?: string) => Promise<void>;
+  loginWithToken: (token: string, redirect?: string) => Promise<void>;
   logout: () => Promise<void>;
   logoutAll: () => Promise<void>;
   refreshProfile: () => Promise<void>;
@@ -96,6 +97,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }
 
+  async function loginWithToken(tokenFromServer: string, redirect?: string) {
+    setLoading(true);
+    try {
+      await setItemAsync('authToken', tokenFromServer);
+      setToken(tokenFromServer);
+      // Fetch profile after saving token
+      await fetchProfile();
+      router.replace((redirect ?? '/') as any);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   async function logout() {
     try {
       // Send logout request to server
@@ -136,6 +150,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     token,
     loading,
     login,
+    loginWithToken,
     logout,
     logoutAll,
     refreshProfile,

--- a/kairo-front/src/lib/api.ts
+++ b/kairo-front/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { getDeviceNameAsync } from 'expo-device';
 import type { ApiError, LoginResponse, RegisterResponse } from './apiTypes';
 import { getItemAsync } from './secureStore';
 
@@ -27,6 +28,33 @@ function mergeHeaders(custom?: HeadersInit): Record<string, string> {
 }
 
 // Fetch wrapper that adds token when possible
+// Internal runtime ApiError implementation. We keep the exported `ApiError` type
+// in `apiTypes.ts` but throw instances of this class so callers can rely on
+// `.status`, `.body` and `.message` being present.
+class ApiFetchError extends Error implements ApiError {
+  status?: number;
+  body?: unknown;
+  code?: string | number;
+
+  constructor(message: string, status?: number, body?: unknown, code?: string | number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+    this.code = code;
+    // maintain proper prototype chain
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  toJSON() {
+    return { name: this.name, message: this.message, status: this.status, body: this.body, code: this.code };
+  }
+}
+
+export function isApiError(e: unknown): e is ApiError {
+  return !!e && typeof e === 'object' && ('status' in (e as object) || 'body' in (e as object) || 'message' in (e as object));
+}
+
 export async function apiFetch<Token = unknown>(path: string, options: FetchOptions = {}): Promise<Token> {
   const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
   const { skipAuth, headers: customHeaders, ...rest } = options;
@@ -39,12 +67,19 @@ export async function apiFetch<Token = unknown>(path: string, options: FetchOpti
       const token = await getItemAsync('authToken');
       if (token) headers.Authorization = `Bearer ${token}`;
     } catch (error) {
-      // Ignore; caller will handle unauthorized
+      // Couldn't read token - don't crash here; callers will handle auth failures.
       console.warn('Failed to read token from secureStore', error);
     }
   }
 
-  const response = await fetch(url, { headers, ...rest });
+  let response: Response;
+  try {
+    response = await fetch(url, { headers, ...rest });
+  } catch (err: any) {
+    // Network error / CORS / DNS etc. Normalize into ApiFetchError
+    const msg = err?.message ?? 'Network request failed';
+    throw new ApiFetchError(msg, undefined, null);
+  }
 
   const contentType = response.headers.get('content-type') || '';
   let body: unknown = null;
@@ -62,32 +97,65 @@ export async function apiFetch<Token = unknown>(path: string, options: FetchOpti
     }
   }
 
+  // Normalize non-OK responses into ApiFetchError with helpful message/body
   if (!response.ok) {
-    const error = new Error(`API error ${response.status}`) as Error & ApiError;
-    error.status = response.status;
-    error.body = body;
-    throw error;
+    // Prefer message from JSON body if present
+    let message = `API error ${response.status}`;
+    if (body && typeof body === 'object') {
+      const b = body as Record<string, unknown>;
+      if (typeof b.message === 'string') message = b.message;
+      else if (typeof b.error === 'string') message = b.error;
+    } else if (typeof body === 'string' && body.length) {
+      message = body;
+    } else if (response.statusText) {
+      message = response.statusText;
+    }
+
+    throw new ApiFetchError(message, response.status, body);
   }
 
+  // Success: return parsed body (may be an object or text). Caller may expect
+  // a `{ data: ... }` shape depending on endpoint; keep returning the parsed body.
   return body as Token;
 }
 
 // Authentication API calls (For the future we can use react-native-device-info to get an actual device name)
-export async function loginRequest(email: string, password: string, device_name = 'mobile'): Promise<LoginResponse> {
+export async function loginRequest(email: string, password: string, device_name?: string): Promise<LoginResponse> {
+  let deviceName = device_name;
+  if (!deviceName) {
+    try {
+      // Use Expo's device API (works in the managed workflow) and fall back to 'mobile'
+      const name = await getDeviceNameAsync();
+      deviceName = typeof name === 'string' && name.length ? name : 'mobile';
+    } catch {
+      deviceName = 'mobile';
+    }
+  }
+
   const response = await apiFetch('/api/auth/login', {
     method: 'POST',
     skipAuth: true,
-    body: JSON.stringify({ email, password, device_name }),
+    body: JSON.stringify({ email, password, device_name: deviceName }),
   });
 
   return response as LoginResponse;
 }
 
-export async function registerRequest(email: string, password: string, device_name = 'mobile'): Promise<RegisterResponse> {
+export async function registerRequest(email: string, password: string, device_name?: string): Promise<RegisterResponse> {
+  let deviceName = device_name;
+  if (!deviceName) {
+    try {
+      const name = await getDeviceNameAsync();
+      deviceName = typeof name === 'string' && name.length ? name : 'mobile';
+    } catch {
+      deviceName = 'mobile';
+    }
+  }
+
   const response = await apiFetch('/api/auth/register', {
     method: 'POST',
     skipAuth: true,
-    body: JSON.stringify({ email, password, device_name }),
+    body: JSON.stringify({ email, password, device_name: deviceName }),
   });
 
   return response as RegisterResponse;

--- a/kairo-front/src/lib/apiTypes.ts
+++ b/kairo-front/src/lib/apiTypes.ts
@@ -1,7 +1,7 @@
 // Shared API response types for profile endpoints
 export type ApiProfileInfo = {
   id: number;
-  user_id: number;
+  user_id: string;
   name: string | null;
   avatar_url?: string | null;
   streak: number;
@@ -10,7 +10,7 @@ export type ApiProfileInfo = {
 };
 
 export type ApiProfileData = {
-  id: number;
+  id: string;
   email: string;
   email_verified_at?: string | null;
   created_at?: string | null;


### PR DESCRIPTION
# Changes implemented
## `Register.tsx`
- Changed `login` to `LoginWithToken`
- Expanded Error logging

## `AuthContext.tsx`
- Added `LoginWithToken` type:
stores:
  - Token (as string)
  - Redirect (optional string)
- `LoginWithToken` async function that accepts a token (without validating it—assumption being that we received a _valid_ token, if for some reason however the Token is invalid in that second it takes to log in (unfortunate backend changes or something) it will throw an error by failing to fetch user profile `fetchProfile`. Redirect is also optional. It's basically only for `(auth)/register` **_(fixes #23)_**

## `package.json`
> ignoring the fact that we were supposed to use yarn (wasn't working for me, that little shit)
- Added `expo-device` dependency to get device info

## `api.ts`
- Expanded error types to avoid using any (vibe coded the shit out of this to get better error messages and avoid errors caused by casting errors as `any`
- `loginRequest` now takes deviceName from `expo-device`, falls back to "mobile" if it fails
> ❗Couldn't test it on Android thanks to expo hating it and possible version mismatch, needs testing❗

## `apiTypes.ts`
- changed `user_id` and `id` to string from integer **_(closes #25)_**

---

# WARNING ⚠️ 
Will create conflict with commit #24 due to imports and formatting (tried to minimalize it, but ya know how it is)

---

### What this accomplishes
fixes #23
closes #25
