### PR TITLE
no-unescaped-entities fix

### DIFF
--- a/kairo-front/app/(auth)/login.tsx
+++ b/kairo-front/app/(auth)/login.tsx
@@ -68,7 +68,7 @@ export default function LoginScreen() {
 			</TouchableOpacity>
 
 			<TouchableOpacity onPress={() => router.push(`/register?redirect=${encodeURIComponent(redirect ?? '/')}`)}>
-				<Text style={styles.subtle}>Don't have an account? Register</Text>
+				<Text style={styles.subtle}>{`Don't have an account? Register`}</Text>
 			</TouchableOpacity>
 		</View>
 	);

--- a/kairo-front/app/+not-found.tsx
+++ b/kairo-front/app/+not-found.tsx
@@ -9,8 +9,8 @@ export default function NotFoundScreen() {
       <Stack.Screen options={{ title: "Lost — You wandered too deep!" }} />
       <View style={styles.container}>
         <Image source={require('../assets/kairo/errors/kairo_404.png')} style={{ width: 200, height: 200, marginBottom: tokens.spacing.sm, borderRadius: 100 }} />
-        <Text style={styles.title}>You're a little lost</Text>
-        <Text style={styles.subtitle}>We couldn't find the page you're looking for.</Text>
+        <Text style={styles.title}>{`You're a little lost`}</Text>
+        <Text style={styles.subtitle}>{`We couldn't find the page you're looking for.`}</Text>
 
         <Link href="/" style={styles.button}>
           <Text style={styles.buttonText}>Take me home</Text>

--- a/kairo-front/app/settings.tsx
+++ b/kairo-front/app/settings.tsx
@@ -114,7 +114,7 @@ export default function SettingsScreen() {
 
           <YStack style={{ width: 320, padding: 16, backgroundColor: '#ffffff', borderRadius: 12, elevation: 2 }}>
             <Text style={{ fontWeight: '700', fontSize: 16 }}>Confirm log out from all devices</Text>
-            <Text style={{ marginTop: 8 }}>This will sign you out of every device where you're logged in. Are you sure?</Text>
+            <Text style={{ marginTop: 8 }}>{`This will sign you out of every device where you're logged in. Are you sure?`}</Text>
 
             <XStack style={{ marginTop: 16, flexDirection: 'row', justifyContent: 'flex-end', gap: 8 }}>
               <Button onPress={() => setConfirmOpen(false)} variant="outlined">Cancel</Button>


### PR DESCRIPTION
# Changes implemented
## followed every case of using `'` with ```{` `}```

example of error causing text: 😢😭❌
```javascript
<Text style={{ marginTop: 8 }}>This will sign you out of every device where you're logged in. Are you sure?</Text>
```

example of fixed text: 😮😎✅ 
```javascript
<Text style={{ marginTop: 8 }}>{`This will sign you out of every device where you're logged in. Are you sure?`}</Text>
```

---

### What this accomplishes
literally nothing, besides getting rid of 3 eslint errors ⚠️
fixes #27 
